### PR TITLE
Implement first pass at FileHeader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.9.1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,8 @@ pub enum EntryPoint {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// EIIdent defines the elf identification fields that define whether the
+/// address size, versions and abi of the file.
 pub struct EIIdent {
     ei_class: EIClass,
     ei_data: EIData,
@@ -320,6 +322,7 @@ pub struct EIIdent {
     ei_abiversion: EIABIVersion,
 }
 
+/// EIIdentParser defines a parser for parsing a raw bitstream into an EIIdent.
 pub struct EIIdentParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], EIIdent> for EIIdentParser {
@@ -355,6 +358,9 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIIdent> for EIIdentParser {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// FileHeader represents a program file header, and contains ELF identifaction
+/// information along with sizing, architechture and additional metadata about
+/// other ELF headers.
 pub struct FileHeader {
     ei_ident: EIIdent,
     r#type: Type,
@@ -363,6 +369,7 @@ pub struct FileHeader {
     entry_point: EntryPoint,
 }
 
+/// FileHeaderParser defines a parser for parsing a raw bitstream into a FileHeader.
 pub struct FileHeaderParser;
 
 impl FileHeaderParser {
@@ -397,7 +404,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], FileHeader> for FileHeaderParser {
     }
 }
 
-pub fn expect_bytes<'a>(expected: &'static [u8]) -> impl Parser<'a, &'a [u8], Vec<u8>> {
+fn expect_bytes<'a>(expected: &'static [u8]) -> impl Parser<'a, &'a [u8], Vec<u8>> {
     move |input: &'a [u8]| {
         let preparse_input = input;
         let expected_len = expected.len();
@@ -410,7 +417,7 @@ pub fn expect_bytes<'a>(expected: &'static [u8]) -> impl Parser<'a, &'a [u8], Ve
     }
 }
 
-pub fn expect_u16<'a>(expected: u16) -> impl Parser<'a, &'a [u8], u16> {
+fn expect_u16<'a>(expected: u16) -> impl Parser<'a, &'a [u8], u16> {
     move |input: &'a [u8]| {
         let preparse_input = input;
         let next: Vec<u8> = input.iter().take(2).copied().collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,12 @@ pub enum Type {
     HIPROC = 0xFFFF,
 }
 
+impl From<Type> for u16 {
+    fn from(src: Type) -> Self {
+        src as u16
+    }
+}
+
 struct TypeParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], Type> for TypeParser {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,11 +65,33 @@ impl<'a> parcel::Parser<'a, &'a [u8], ABI> for ABIParser {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Type {
+    None,
+    Rel,
+    Exec,
+    Dyn,
+    Core,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Machine {
+    X86,
+    X86_64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EntryPoint(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ELFHeader {
     class: Class,
     endianness: Endianness,
     version: Version,
     abi: ABI,
+    r#type: Type,
+    machine: Machine,
+    vers: Version,
+    entry_point: EntryPoint,
 }
 
 pub struct ELFParser;
@@ -90,6 +112,10 @@ impl<'a> parcel::Parser<'a, &'a [u8], ELFHeader> for ELFParser {
             endianness,
             version,
             abi,
+            r#type: Type::None,
+            machine: Machine::X86,
+            vers: version,
+            entry_point: EntryPoint(0),
         })
         .parse(input)
     }
@@ -125,6 +151,10 @@ mod tests {
                 endianness: Endianness::Little,
                 version: Version::One,
                 abi: ABI::SysV,
+                r#type: Type::None,
+                machine: Machine::X86_64,
+                vers: Version::One,
+                entry_point: EntryPoint(0),
             }
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -660,7 +660,6 @@ fn match_u32<'a>(endianness: EIData) -> impl Parser<'a, &'a [u8], u32> {
 
     parcel::take_n(any_byte(), 4).map(move |b| {
         b.try_into()
-            .map(|b| b)
             .map(|ep| match endianness {
                 EIData::Little => u32::from_le_bytes(ep),
                 EIData::Big => u32::from_be_bytes(ep),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,24 +274,67 @@ impl<'a> parcel::Parser<'a, &'a [u8], Machine> for MachineParser {
         use std::convert::TryInto;
         let preparse_input = input;
 
-        // Should be safe to unwrap.
-        let mcode = input
+        input
             .iter()
             .take(2)
             .copied()
             .collect::<Vec<u8>>()
             .try_into()
-            .unwrap();
-
-        match u16::from_ne_bytes(mcode) {
-            0x0000 => Some(Machine::None),
-            0x0003 => Some(Machine::X386),
-            0x003e => Some(Machine::X86_64),
-            _ => None,
-        }
-        .map_or(Ok(MatchStatus::NoMatch(preparse_input)), |m| {
-            Ok(MatchStatus::Match((&preparse_input[2..], m)))
-        })
+            .map(|mcode| match u16::from_ne_bytes(mcode) {
+                0x00 => Some(Machine::None),
+                0x01 => Some(Machine::M32),
+                0x02 => Some(Machine::SPARC),
+                0x03 => Some(Machine::X386),
+                0x04 => Some(Machine::M68k),
+                0x05 => Some(Machine::M88k),
+                0x06 => Some(Machine::IntelMCU),
+                0x07 => Some(Machine::Intel80860),
+                0x08 => Some(Machine::MIPS),
+                0x09 => Some(Machine::S370),
+                0x0A => Some(Machine::MIPSRS3LE),
+                0x0E => Some(Machine::PARISC),
+                0x13 => Some(Machine::I960),
+                0x14 => Some(Machine::PPC),
+                0x15 => Some(Machine::PPC64),
+                0x16 => Some(Machine::S390),
+                0x24 => Some(Machine::V800),
+                0x25 => Some(Machine::FR20),
+                0x26 => Some(Machine::RH32),
+                0x27 => Some(Machine::RCE),
+                0x28 => Some(Machine::ARM),
+                0x29 => Some(Machine::Alpha),
+                0x2A => Some(Machine::SH),
+                0x2B => Some(Machine::SPARCV9),
+                0x2C => Some(Machine::Tricore),
+                0x2D => Some(Machine::ARC),
+                0x2E => Some(Machine::H8300),
+                0x2F => Some(Machine::H8_300H),
+                0x30 => Some(Machine::H8s),
+                0x31 => Some(Machine::H8500),
+                0x32 => Some(Machine::IA64),
+                0x33 => Some(Machine::MIPSX),
+                0x34 => Some(Machine::Coldfire),
+                0x35 => Some(Machine::M68HC12),
+                0x36 => Some(Machine::MMA),
+                0x37 => Some(Machine::PCP),
+                0x38 => Some(Machine::NCPU),
+                0x39 => Some(Machine::NDR1),
+                0x3a => Some(Machine::Starcore),
+                0x3B => Some(Machine::ME16),
+                0x3C => Some(Machine::ST100),
+                0x3D => Some(Machine::TinyJ),
+                0x3e => Some(Machine::X86_64),
+                0x8C => Some(Machine::S320C600),
+                0xB9 => Some(Machine::AARCH64),
+                0xFa => Some(Machine::RISCV),
+                0xFB => Some(Machine::BPF),
+                0x101 => Some(Machine::WDC65C817),
+                _ => None,
+            })
+            .unwrap()
+            .map_or(Ok(MatchStatus::NoMatch(preparse_input)), |m| {
+                Ok(MatchStatus::Match((&preparse_input[2..], m)))
+            })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,6 +404,9 @@ impl<'a> parcel::Parser<'a, &'a [u8], FileHeader> for FileHeaderParser {
     }
 }
 
+/// Matches a single provided static byte array, returning a match if the next
+/// bytes in the array match the expected byte array. Otherwise, a `NoMatch` is
+/// returned.
 fn expect_bytes<'a>(expected: &'static [u8]) -> impl Parser<'a, &'a [u8], Vec<u8>> {
     move |input: &'a [u8]| {
         let preparse_input = input;
@@ -417,6 +420,9 @@ fn expect_bytes<'a>(expected: &'static [u8]) -> impl Parser<'a, &'a [u8], Vec<u8
     }
 }
 
+/// Matches a single provided static u16, returning a match if the next
+/// two bytes in the array match the expected u16. Otherwise, a `NoMatch` is
+/// returned.
 fn expect_u16<'a>(expected: u16) -> impl Parser<'a, &'a [u8], u16> {
     move |input: &'a [u8]| {
         let preparse_input = input;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ impl std::fmt::Debug for FileErr {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum EIClass {
+enum EIClass {
     ThirtyTwoBit = 0x01,
     SixtyFourBit = 0x02,
 }
@@ -45,7 +45,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIClass> for EIClassParser {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum EIData {
+enum EIData {
     Little = 0x01,
     Big = 0x02,
 }
@@ -70,7 +70,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIData> for EIDataParser {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum EIVersion {
+enum EIVersion {
     One = 1,
 }
 
@@ -92,7 +92,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIVersion> for EIVersionParser {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum EIOSABI {
+enum EIOSABI {
     SysV = 0x00,
     HPUX = 0x01,
     NetBSD = 0x02,
@@ -149,7 +149,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIOSABI> for EIOSABIParser {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum EIABIVersion {
+enum EIABIVersion {
     Zero = 0x00,
     One = 0x01,
 }
@@ -174,7 +174,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIABIVersion> for EIABIVersionParser {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-pub enum Type {
+enum Type {
     None = 0x00,
     Rel = 0x01,
     Exec = 0x02,
@@ -213,7 +213,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], Type> for TypeParser {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-pub enum Machine {
+enum Machine {
     None = 0x00,
     M32 = 0x01,
     SPARC = 0x02,
@@ -343,7 +343,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], Machine> for MachineParser {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
-pub enum Version {
+enum Version {
     One = 0x01,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use parcel::parsers::byte::expect_byte;
 use parcel::prelude::v1::*;
 
 // Type Metadata
@@ -35,10 +36,8 @@ struct EIClassParser;
 impl<'a> parcel::Parser<'a, &'a [u8], EIClass> for EIClassParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIClass> {
         parcel::one_of(vec![
-            parcel::parsers::byte::expect_byte(EIClass::ThirtyTwoBit as u8)
-                .map(|_| EIClass::ThirtyTwoBit),
-            parcel::parsers::byte::expect_byte(EIClass::SixtyFourBit as u8)
-                .map(|_| EIClass::SixtyFourBit),
+            expect_byte(EIClass::ThirtyTwoBit as u8).map(|_| EIClass::ThirtyTwoBit),
+            expect_byte(EIClass::SixtyFourBit as u8).map(|_| EIClass::SixtyFourBit),
         ])
         .parse(input)
     }
@@ -62,8 +61,8 @@ struct EIDataParser;
 impl<'a> parcel::Parser<'a, &'a [u8], EIData> for EIDataParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIData> {
         parcel::one_of(vec![
-            parcel::parsers::byte::expect_byte(EIData::Little as u8).map(|_| EIData::Little),
-            parcel::parsers::byte::expect_byte(EIData::Big as u8).map(|_| EIData::Big),
+            expect_byte(EIData::Little as u8).map(|_| EIData::Little),
+            expect_byte(EIData::Big as u8).map(|_| EIData::Big),
         ])
         .parse(input)
     }
@@ -85,7 +84,7 @@ struct EIVersionParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], EIVersion> for EIVersionParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIVersion> {
-        parcel::parsers::byte::expect_byte(EIVersion::One as u8)
+        expect_byte(EIVersion::One as u8)
             .map(|_| EIVersion::One)
             .parse(input)
     }
@@ -124,7 +123,6 @@ struct EIOSABIParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], EIOSABI> for EIOSABIParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIOSABI> {
-        use parcel::parsers::byte::expect_byte;
         parcel::one_of(vec![
             expect_byte(EIOSABI::SysV as u8).map(|_| EIOSABI::SysV),
             expect_byte(EIOSABI::HPUX as u8).map(|_| EIOSABI::HPUX),
@@ -166,7 +164,6 @@ struct EIABIVersionParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], EIABIVersion> for EIABIVersionParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIABIVersion> {
-        use parcel::parsers::byte::expect_byte;
         parcel::one_of(vec![
             expect_byte(EIABIVersion::Zero as u8).map(|_| EIABIVersion::Zero),
             expect_byte(EIABIVersion::One as u8).map(|_| EIABIVersion::One),
@@ -360,28 +357,9 @@ struct VersionParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], Version> for VersionParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Version> {
-        parcel::parsers::byte::expect_byte(Version::One as u8)
+        expect_byte(Version::One as u8)
             .map(|_| Version::One)
             .parse(input)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AddressOffset {
-    ThirtyTwoBit(u32),
-    SixtyFourBit(u64),
-}
-
-struct AddressOffsetParser(EIClass);
-
-impl<'a> parcel::Parser<'a, &'a [u8], AddressOffset> for AddressOffsetParser {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], AddressOffset> {
-        let class = self.0;
-        match class {
-            EIClass::ThirtyTwoBit => match_u32().map(|ep| AddressOffset::ThirtyTwoBit(ep)),
-            EIClass::SixtyFourBit => match_u64().map(|ep| AddressOffset::SixtyFourBit(ep)),
-        }
-        .parse(input)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,17 +14,15 @@ impl std::fmt::Debug for FileErr {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum EIClass {
-    ThirtyTwo,
-    SixtyFour,
+    ThirtyTwo = 0x01,
+    SixtyFour = 0x02,
 }
 
 impl From<EIClass> for u8 {
     fn from(src: EIClass) -> Self {
-        match src {
-            EIClass::ThirtyTwo => 1,
-            EIClass::SixtyFour => 2,
-        }
+        src as u8
     }
 }
 
@@ -88,7 +86,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIVersion> for EIVersionParser {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u16)]
+#[repr(u8)]
 pub enum EIOSABI {
     SysV = 0x00,
     HPUX = 0x01,
@@ -110,9 +108,9 @@ pub enum EIOSABI {
     OpenVOS = 0x12,
 }
 
-impl From<EIOSABI> for u16 {
+impl From<EIOSABI> for u8 {
     fn from(src: EIOSABI) -> Self {
-        src as u16
+        src as u8
     }
 }
 
@@ -120,25 +118,52 @@ struct EIOSABIParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], EIOSABI> for EIOSABIParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIOSABI> {
+        use parcel::parsers::byte::expect_byte;
         parcel::one_of(vec![
-            expect_u16(EIOSABI::SysV as u16).map(|_| EIOSABI::SysV),
-            expect_u16(EIOSABI::HPUX as u16).map(|_| EIOSABI::HPUX),
-            expect_u16(EIOSABI::NetBSD as u16).map(|_| EIOSABI::NetBSD),
-            expect_u16(EIOSABI::Linux as u16).map(|_| EIOSABI::Linux),
-            expect_u16(EIOSABI::GNUHurd as u16).map(|_| EIOSABI::GNUHurd),
-            expect_u16(EIOSABI::Solaris as u16).map(|_| EIOSABI::Solaris),
-            expect_u16(EIOSABI::AIX as u16).map(|_| EIOSABI::AIX),
-            expect_u16(EIOSABI::IRIX as u16).map(|_| EIOSABI::IRIX),
-            expect_u16(EIOSABI::FreeBSD as u16).map(|_| EIOSABI::FreeBSD),
-            expect_u16(EIOSABI::Tru64 as u16).map(|_| EIOSABI::Tru64),
-            expect_u16(EIOSABI::Novell as u16).map(|_| EIOSABI::Novell),
-            expect_u16(EIOSABI::OpenBSD as u16).map(|_| EIOSABI::OpenBSD),
-            expect_u16(EIOSABI::OpenVMS as u16).map(|_| EIOSABI::OpenVMS),
-            expect_u16(EIOSABI::NonStop as u16).map(|_| EIOSABI::NonStop),
-            expect_u16(EIOSABI::Aros as u16).map(|_| EIOSABI::Aros),
-            expect_u16(EIOSABI::Fenix as u16).map(|_| EIOSABI::Fenix),
-            expect_u16(EIOSABI::CloudABI as u16).map(|_| EIOSABI::CloudABI),
-            expect_u16(EIOSABI::OpenVOS as u16).map(|_| EIOSABI::OpenVOS),
+            expect_byte(EIOSABI::SysV as u8).map(|_| EIOSABI::SysV),
+            expect_byte(EIOSABI::HPUX as u8).map(|_| EIOSABI::HPUX),
+            expect_byte(EIOSABI::NetBSD as u8).map(|_| EIOSABI::NetBSD),
+            expect_byte(EIOSABI::Linux as u8).map(|_| EIOSABI::Linux),
+            expect_byte(EIOSABI::GNUHurd as u8).map(|_| EIOSABI::GNUHurd),
+            expect_byte(EIOSABI::Solaris as u8).map(|_| EIOSABI::Solaris),
+            expect_byte(EIOSABI::AIX as u8).map(|_| EIOSABI::AIX),
+            expect_byte(EIOSABI::IRIX as u8).map(|_| EIOSABI::IRIX),
+            expect_byte(EIOSABI::FreeBSD as u8).map(|_| EIOSABI::FreeBSD),
+            expect_byte(EIOSABI::Tru64 as u8).map(|_| EIOSABI::Tru64),
+            expect_byte(EIOSABI::Novell as u8).map(|_| EIOSABI::Novell),
+            expect_byte(EIOSABI::OpenBSD as u8).map(|_| EIOSABI::OpenBSD),
+            expect_byte(EIOSABI::OpenVMS as u8).map(|_| EIOSABI::OpenVMS),
+            expect_byte(EIOSABI::NonStop as u8).map(|_| EIOSABI::NonStop),
+            expect_byte(EIOSABI::Aros as u8).map(|_| EIOSABI::Aros),
+            expect_byte(EIOSABI::Fenix as u8).map(|_| EIOSABI::Fenix),
+            expect_byte(EIOSABI::CloudABI as u8).map(|_| EIOSABI::CloudABI),
+            expect_byte(EIOSABI::OpenVOS as u8).map(|_| EIOSABI::OpenVOS),
+        ])
+        .parse(input)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum EIABIVersion {
+    Zero = 0x00,
+    One = 0x01,
+}
+
+impl From<EIABIVersion> for u8 {
+    fn from(src: EIABIVersion) -> Self {
+        src as u8
+    }
+}
+
+struct EIABIVersionParser;
+
+impl<'a> parcel::Parser<'a, &'a [u8], EIABIVersion> for EIABIVersionParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIABIVersion> {
+        use parcel::parsers::byte::expect_byte;
+        parcel::one_of(vec![
+            expect_byte(EIABIVersion::Zero as u8).map(|_| EIABIVersion::Zero),
+            expect_byte(EIABIVersion::One as u8).map(|_| EIABIVersion::One),
         ])
         .parse(input)
     }
@@ -287,11 +312,51 @@ pub enum EntryPoint {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FileHeader {
+pub struct EIIdent {
     ei_class: EIClass,
     ei_data: EIData,
     ei_version: EIVersion,
     ei_osabi: EIOSABI,
+    ei_abiversion: EIABIVersion,
+}
+
+pub struct EIIdentParser;
+
+impl<'a> parcel::Parser<'a, &'a [u8], EIIdent> for EIIdentParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIIdent> {
+        parcel::right(parcel::join(
+            expect_bytes(&[0x7f, 0x45, 0x4c, 0x46]),
+            parcel::join(
+                EIClassParser,
+                parcel::join(
+                    EIDataParser,
+                    parcel::join(
+                        EIVersionParser,
+                        parcel::join(EIOSABIParser, EIABIVersionParser),
+                    ),
+                ),
+            )
+            // skip padding
+            .and_then(|last| {
+                parcel::take_n(parcel::parsers::byte::any_byte(), 7).map(move |_| last)
+            }),
+        ))
+        .map(
+            |(ei_class, (ei_data, (ei_version, (ei_osabi, ei_abiversion))))| EIIdent {
+                ei_class,
+                ei_data,
+                ei_version,
+                ei_osabi,
+                ei_abiversion,
+            },
+        )
+        .parse(input)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileHeader {
+    ei_ident: EIIdent,
     r#type: Type,
     machine: Machine,
     version: Version,
@@ -301,43 +366,34 @@ pub struct FileHeader {
 pub struct FileHeaderParser;
 
 impl FileHeaderParser {
-    /// preamble parses the elf magic bytes and class, returning the class if
+    /// identifier parses the elf magic bytes and class, returning the class if
     /// the elf file has a valid preamble.
-    pub fn preamble(input: &[u8]) -> Result<EIClass, FileErr> {
-        parcel::right(parcel::join(
-            expect_bytes(&[0x7f, 0x45, 0x4c, 0x46]),
-            EIClassParser,
-        ))
-        .parse(input)
-        .map(|ms| match ms {
-            MatchStatus::Match((_, class)) => Some(class),
-            MatchStatus::NoMatch(_) => None,
-        })
-        .map_err(|_| FileErr::InvalidFile)?
-        .ok_or(FileErr::InvalidFile)
+    pub fn identifier(input: &[u8]) -> Result<EIIdent, FileErr> {
+        EIIdentParser
+            .parse(input)
+            .map(|ms| match ms {
+                MatchStatus::Match((_, ei_ident)) => Some(ei_ident),
+                MatchStatus::NoMatch(_) => None,
+            })
+            .map_err(|_| FileErr::InvalidFile)?
+            .ok_or(FileErr::InvalidFile)
     }
 }
 
 impl<'a> parcel::Parser<'a, &'a [u8], FileHeader> for FileHeaderParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], FileHeader> {
-        let ei_class = Self::preamble(input).map_err(|e| format!("{:?}", e))?;
+        let ei_ident = Self::identifier(input).map_err(|e| format!("{:?}", e))?;
 
-        parcel::join(EIDataParser, parcel::join(EIVersionParser, EIOSABIParser))
-            // skip padding
-            .and_then(|last| {
-                parcel::take_n(parcel::parsers::byte::any_byte(), 7).map(move |_| last)
-            })
-            .map(move |(ei_data, (ei_version, ei_osabi))| FileHeader {
-                ei_class,
-                ei_data,
-                ei_version,
-                ei_osabi,
+        Ok(MatchStatus::Match((
+            &input[16..],
+            FileHeader {
+                ei_ident,
                 r#type: Type::None,
                 machine: Machine::X86_64,
                 version: Version::One,
                 entry_point: EntryPoint::SixtyFour(0),
-            })
-            .parse(&input[5..])
+            },
+        )))
     }
 }
 
@@ -372,35 +428,44 @@ mod tests {
 
     #[test]
     fn parse_preamble_should_return_expected_results() {
-        let thirty_two_bit_input = [0x7f, 0x45, 0x4c, 0x46, 0x01];
-        let sixty_four_bit_input = [0x7f, 0x45, 0x4c, 0x46, 0x02];
+        let thirty_two_bit_input = [
+            0x7f, 0x45, 0x4c, 0x46, 0x01, 0x01, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00,
+        ];
+        let sixty_four_bit_input = [
+            0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00,
+        ];
         let invalid_input = [0xff, 0xff, 0xff, 0xff, 0xff];
 
         assert_eq!(
             Ok(EIClass::ThirtyTwo),
-            FileHeaderParser::preamble(&thirty_two_bit_input)
+            FileHeaderParser::identifier(&thirty_two_bit_input).map(|ident| ident.ei_class)
         );
         assert_eq!(
             Ok(EIClass::SixtyFour),
-            FileHeaderParser::preamble(&sixty_four_bit_input)
+            FileHeaderParser::identifier(&sixty_four_bit_input).map(|ident| ident.ei_class)
         );
-        assert!(FileHeaderParser::preamble(&invalid_input).is_err());
+        assert!(FileHeaderParser::identifier(&invalid_input).is_err());
     }
 
     #[test]
     fn parse_known_good_header() {
         let input = [
-            0x7f, 0x45, 0x4c, 0x46, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x7f, 0x45, 0x4c, 0x46, 0x01, 0x01, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00,
         ];
 
         assert_eq!(
             FileHeaderParser.parse(&input).unwrap().unwrap(),
             FileHeader {
-                ei_class: EIClass::ThirtyTwo,
-                ei_data: EIData::Little,
-                ei_version: EIVersion::One,
-                ei_osabi: EIOSABI::SysV,
+                ei_ident: EIIdent {
+                    ei_class: EIClass::ThirtyTwo,
+                    ei_data: EIData::Little,
+                    ei_version: EIVersion::One,
+                    ei_osabi: EIOSABI::SysV,
+                    ei_abiversion: EIABIVersion::One,
+                },
                 r#type: Type::None,
                 machine: Machine::X86_64,
                 version: Version::One,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,85 @@
+use parcel::prelude::v1::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Class {
+    ThirtyTwo,
+    SixtyFour,
+}
+
+struct ClassParser;
+
+impl<'a> parcel::Parser<'a, &'a [u8], Class> for ClassParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Class> {
+        parcel::parsers::byte::expect_byte(0x00)
+            .map(|_| Class::ThirtyTwo)
+            .or(|| parcel::parsers::byte::expect_byte(0x01).map(|_| Class::SixtyFour))
+            .parse(input)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Endianness {
+    Little,
+    Big,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Version {
+    One,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ABI {
+    SysV,
+}
+
+struct ABIParser;
+
+impl<'a> parcel::Parser<'a, &'a [u8], ABI> for ABIParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], ABI> {
+        parcel::parsers::byte::expect_byte(0x00)
+            .map(|_| ABI::SysV)
+            .parse(input)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ELFHeader {
+    class: Class,
+    endianess: Endianness,
+    version: Version,
+    abi: ABI,
+}
+
+impl<'a> parcel::Parser<'a, &'a [u8], ELFHeader> for ELFHeader {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], ELFHeader> {
+        parcel::right(parcel::join(
+            expect_bytes(&[0x7f, 0x45, 0x4c, 0x46]),
+            parcel::join(ClassParser, ABIParser),
+        ))
+        .map(|(class, abi)| Self {
+            class,
+            endianess: Endianness::Little,
+            version: Version::One,
+            abi,
+        })
+        .parse(input)
+    }
+}
+
+pub fn expect_bytes<'a>(expected: &'static [u8]) -> impl Parser<'a, &'a [u8], Vec<u8>> {
+    move |input: &'a [u8]| {
+        let preparse_input = input;
+        let expected_len = expected.len();
+        let next: Vec<u8> = input.iter().take(expected_len).copied().collect();
+        if next == expected {
+            Ok(MatchStatus::Match((&input[expected_len..], next)))
+        } else {
+            Ok(MatchStatus::NoMatch(preparse_input))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,27 +14,27 @@ impl std::fmt::Debug for FileErr {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Class {
+pub enum EIClass {
     ThirtyTwo,
     SixtyFour,
 }
 
-impl From<Class> for u8 {
-    fn from(src: Class) -> Self {
+impl From<EIClass> for u8 {
+    fn from(src: EIClass) -> Self {
         match src {
-            Class::ThirtyTwo => 1,
-            Class::SixtyFour => 2,
+            EIClass::ThirtyTwo => 1,
+            EIClass::SixtyFour => 2,
         }
     }
 }
 
-struct ClassParser;
+struct EIClassParser;
 
-impl<'a> parcel::Parser<'a, &'a [u8], Class> for ClassParser {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Class> {
+impl<'a> parcel::Parser<'a, &'a [u8], EIClass> for EIClassParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIClass> {
         parcel::one_of(vec![
-            parcel::parsers::byte::expect_byte(0x01).map(|_| Class::ThirtyTwo),
-            parcel::parsers::byte::expect_byte(0x02).map(|_| Class::SixtyFour),
+            parcel::parsers::byte::expect_byte(0x01).map(|_| EIClass::ThirtyTwo),
+            parcel::parsers::byte::expect_byte(0x02).map(|_| EIClass::SixtyFour),
         ])
         .parse(input)
     }
@@ -42,25 +42,24 @@ impl<'a> parcel::Parser<'a, &'a [u8], Class> for ClassParser {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum Endianness {
+pub enum EIData {
     Little = 0x01,
     Big = 0x02,
 }
 
-impl From<Endianness> for u8 {
-    fn from(src: Endianness) -> Self {
+impl From<EIData> for u8 {
+    fn from(src: EIData) -> Self {
         src as u8
     }
 }
 
-struct EndiannessParser;
+struct EIDataParser;
 
-impl<'a> parcel::Parser<'a, &'a [u8], Endianness> for EndiannessParser {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Endianness> {
+impl<'a> parcel::Parser<'a, &'a [u8], EIData> for EIDataParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIData> {
         parcel::one_of(vec![
-            parcel::parsers::byte::expect_byte(Endianness::Little as u8)
-                .map(|_| Endianness::Little),
-            parcel::parsers::byte::expect_byte(Endianness::Big as u8).map(|_| Endianness::Big),
+            parcel::parsers::byte::expect_byte(EIData::Little as u8).map(|_| EIData::Little),
+            parcel::parsers::byte::expect_byte(EIData::Big as u8).map(|_| EIData::Big),
         ])
         .parse(input)
     }
@@ -68,29 +67,29 @@ impl<'a> parcel::Parser<'a, &'a [u8], Endianness> for EndiannessParser {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum ABIVersion {
+pub enum EIVersion {
     One = 1,
 }
 
-impl From<ABIVersion> for u8 {
-    fn from(src: ABIVersion) -> Self {
+impl From<EIVersion> for u8 {
+    fn from(src: EIVersion) -> Self {
         src as u8
     }
 }
 
-struct ABIVersionParser;
+struct EIVersionParser;
 
-impl<'a> parcel::Parser<'a, &'a [u8], ABIVersion> for ABIVersionParser {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], ABIVersion> {
-        parcel::parsers::byte::expect_byte(ABIVersion::One as u8)
-            .map(|_| ABIVersion::One)
+impl<'a> parcel::Parser<'a, &'a [u8], EIVersion> for EIVersionParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIVersion> {
+        parcel::parsers::byte::expect_byte(EIVersion::One as u8)
+            .map(|_| EIVersion::One)
             .parse(input)
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-pub enum ABI {
+pub enum EIOSABI {
     SysV = 0x00,
     HPUX = 0x01,
     NetBSD = 0x02,
@@ -111,35 +110,35 @@ pub enum ABI {
     OpenVOS = 0x12,
 }
 
-impl From<ABI> for u16 {
-    fn from(src: ABI) -> Self {
+impl From<EIOSABI> for u16 {
+    fn from(src: EIOSABI) -> Self {
         src as u16
     }
 }
 
-struct ABIParser;
+struct EIOSABIParser;
 
-impl<'a> parcel::Parser<'a, &'a [u8], ABI> for ABIParser {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], ABI> {
+impl<'a> parcel::Parser<'a, &'a [u8], EIOSABI> for EIOSABIParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIOSABI> {
         parcel::one_of(vec![
-            expect_u16(ABI::SysV as u16).map(|_| ABI::SysV),
-            expect_u16(ABI::HPUX as u16).map(|_| ABI::HPUX),
-            expect_u16(ABI::NetBSD as u16).map(|_| ABI::NetBSD),
-            expect_u16(ABI::Linux as u16).map(|_| ABI::Linux),
-            expect_u16(ABI::GNUHurd as u16).map(|_| ABI::GNUHurd),
-            expect_u16(ABI::Solaris as u16).map(|_| ABI::Solaris),
-            expect_u16(ABI::AIX as u16).map(|_| ABI::AIX),
-            expect_u16(ABI::IRIX as u16).map(|_| ABI::IRIX),
-            expect_u16(ABI::FreeBSD as u16).map(|_| ABI::FreeBSD),
-            expect_u16(ABI::Tru64 as u16).map(|_| ABI::Tru64),
-            expect_u16(ABI::Novell as u16).map(|_| ABI::Novell),
-            expect_u16(ABI::OpenBSD as u16).map(|_| ABI::OpenBSD),
-            expect_u16(ABI::OpenVMS as u16).map(|_| ABI::OpenVMS),
-            expect_u16(ABI::NonStop as u16).map(|_| ABI::NonStop),
-            expect_u16(ABI::Aros as u16).map(|_| ABI::Aros),
-            expect_u16(ABI::Fenix as u16).map(|_| ABI::Fenix),
-            expect_u16(ABI::CloudABI as u16).map(|_| ABI::CloudABI),
-            expect_u16(ABI::OpenVOS as u16).map(|_| ABI::OpenVOS),
+            expect_u16(EIOSABI::SysV as u16).map(|_| EIOSABI::SysV),
+            expect_u16(EIOSABI::HPUX as u16).map(|_| EIOSABI::HPUX),
+            expect_u16(EIOSABI::NetBSD as u16).map(|_| EIOSABI::NetBSD),
+            expect_u16(EIOSABI::Linux as u16).map(|_| EIOSABI::Linux),
+            expect_u16(EIOSABI::GNUHurd as u16).map(|_| EIOSABI::GNUHurd),
+            expect_u16(EIOSABI::Solaris as u16).map(|_| EIOSABI::Solaris),
+            expect_u16(EIOSABI::AIX as u16).map(|_| EIOSABI::AIX),
+            expect_u16(EIOSABI::IRIX as u16).map(|_| EIOSABI::IRIX),
+            expect_u16(EIOSABI::FreeBSD as u16).map(|_| EIOSABI::FreeBSD),
+            expect_u16(EIOSABI::Tru64 as u16).map(|_| EIOSABI::Tru64),
+            expect_u16(EIOSABI::Novell as u16).map(|_| EIOSABI::Novell),
+            expect_u16(EIOSABI::OpenBSD as u16).map(|_| EIOSABI::OpenBSD),
+            expect_u16(EIOSABI::OpenVMS as u16).map(|_| EIOSABI::OpenVMS),
+            expect_u16(EIOSABI::NonStop as u16).map(|_| EIOSABI::NonStop),
+            expect_u16(EIOSABI::Aros as u16).map(|_| EIOSABI::Aros),
+            expect_u16(EIOSABI::Fenix as u16).map(|_| EIOSABI::Fenix),
+            expect_u16(EIOSABI::CloudABI as u16).map(|_| EIOSABI::CloudABI),
+            expect_u16(EIOSABI::OpenVOS as u16).map(|_| EIOSABI::OpenVOS),
         ])
         .parse(input)
     }
@@ -289,10 +288,10 @@ pub enum EntryPoint {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FileHeader {
-    class: Class,
-    endianness: Endianness,
-    abi_version: ABIVersion,
-    abi: ABI,
+    ei_class: EIClass,
+    ei_data: EIData,
+    ei_version: EIVersion,
+    ei_osabi: EIOSABI,
     r#type: Type,
     machine: Machine,
     version: Version,
@@ -304,10 +303,10 @@ pub struct FileHeaderParser;
 impl FileHeaderParser {
     /// preamble parses the elf magic bytes and class, returning the class if
     /// the elf file has a valid preamble.
-    pub fn preamble(input: &[u8]) -> Result<Class, FileErr> {
+    pub fn preamble(input: &[u8]) -> Result<EIClass, FileErr> {
         parcel::right(parcel::join(
             expect_bytes(&[0x7f, 0x45, 0x4c, 0x46]),
-            ClassParser,
+            EIClassParser,
         ))
         .parse(input)
         .map(|ms| match ms {
@@ -321,18 +320,18 @@ impl FileHeaderParser {
 
 impl<'a> parcel::Parser<'a, &'a [u8], FileHeader> for FileHeaderParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], FileHeader> {
-        let class = Self::preamble(input).map_err(|e| format!("{:?}", e))?;
+        let ei_class = Self::preamble(input).map_err(|e| format!("{:?}", e))?;
 
-        parcel::join(EndiannessParser, parcel::join(ABIVersionParser, ABIParser))
+        parcel::join(EIDataParser, parcel::join(EIVersionParser, EIOSABIParser))
             // skip padding
             .and_then(|last| {
                 parcel::take_n(parcel::parsers::byte::any_byte(), 7).map(move |_| last)
             })
-            .map(move |(endianness, (abi_version, abi))| FileHeader {
-                class,
-                endianness,
-                abi_version,
-                abi,
+            .map(move |(ei_data, (ei_version, ei_osabi))| FileHeader {
+                ei_class,
+                ei_data,
+                ei_version,
+                ei_osabi,
                 r#type: Type::None,
                 machine: Machine::X86_64,
                 version: Version::One,
@@ -378,11 +377,11 @@ mod tests {
         let invalid_input = [0xff, 0xff, 0xff, 0xff, 0xff];
 
         assert_eq!(
-            Ok(Class::ThirtyTwo),
+            Ok(EIClass::ThirtyTwo),
             FileHeaderParser::preamble(&thirty_two_bit_input)
         );
         assert_eq!(
-            Ok(Class::SixtyFour),
+            Ok(EIClass::SixtyFour),
             FileHeaderParser::preamble(&sixty_four_bit_input)
         );
         assert!(FileHeaderParser::preamble(&invalid_input).is_err());
@@ -398,10 +397,10 @@ mod tests {
         assert_eq!(
             FileHeaderParser.parse(&input).unwrap().unwrap(),
             FileHeader {
-                class: Class::ThirtyTwo,
-                endianness: Endianness::Little,
-                abi_version: ABIVersion::One,
-                abi: ABI::SysV,
+                ei_class: EIClass::ThirtyTwo,
+                ei_data: EIData::Little,
+                ei_version: EIVersion::One,
+                ei_osabi: EIOSABI::SysV,
                 r#type: Type::None,
                 machine: Machine::X86_64,
                 version: Version::One,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,15 @@ pub enum Class {
     SixtyFour,
 }
 
+impl From<Class> for u8 {
+    fn from(src: Class) -> Self {
+        match src {
+            Class::ThirtyTwo => 1,
+            Class::SixtyFour => 2,
+        }
+    }
+}
+
 struct ClassParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], Class> for ClassParser {
@@ -18,72 +27,201 @@ impl<'a> parcel::Parser<'a, &'a [u8], Class> for ClassParser {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum Endianness {
-    Little,
-    Big,
+    Little = 0x01,
+    Big = 0x02,
+}
+
+impl From<Endianness> for u8 {
+    fn from(src: Endianness) -> Self {
+        src as u8
+    }
 }
 
 struct EndiannessParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], Endianness> for EndiannessParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Endianness> {
-        parcel::parsers::byte::expect_byte(0x01)
-            .map(|_| Endianness::Little)
-            .or(|| parcel::parsers::byte::expect_byte(0x02).map(|_| Endianness::Big))
-            .parse(input)
+        parcel::one_of(vec![
+            parcel::parsers::byte::expect_byte(Endianness::Little as u8)
+                .map(|_| Endianness::Little),
+            parcel::parsers::byte::expect_byte(Endianness::Big as u8).map(|_| Endianness::Big),
+        ])
+        .parse(input)
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum Version {
-    One,
+    One = 1,
+}
+
+impl From<Version> for u8 {
+    fn from(src: Version) -> Self {
+        src as u8
+    }
 }
 
 struct VersionParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], Version> for VersionParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Version> {
-        parcel::parsers::byte::expect_byte(0x01)
+        parcel::parsers::byte::expect_byte(Version::One as u8)
             .map(|_| Version::One)
             .parse(input)
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
 pub enum ABI {
-    SysV,
+    SysV = 0x00,
+    HPUX = 0x01,
+    NetBSD = 0x02,
+    Linux = 0x03,
+    GNUHurd = 0x04,
+    Solaris = 0x06,
+    AIX = 0x07,
+    IRIX = 0x08,
+    FreeBSD = 0x09,
+    Tru64 = 0x0A,
+    Novell = 0x0B,
+    OpenBSD = 0x0C,
+    OpenVMS = 0x0D,
+    NonStop = 0x0E,
+    Aros = 0x0F,
+    Fenix = 0x10,
+    CloudABI = 0x11,
+    OpenVOS = 0x12,
+}
+
+impl From<ABI> for u16 {
+    fn from(src: ABI) -> Self {
+        src as u16
+    }
 }
 
 struct ABIParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], ABI> for ABIParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], ABI> {
-        parcel::parsers::byte::expect_byte(0x00)
-            .map(|_| ABI::SysV)
-            .parse(input)
+        parcel::one_of(vec![
+            expect_u16(ABI::SysV as u16).map(|_| ABI::SysV),
+            expect_u16(ABI::HPUX as u16).map(|_| ABI::HPUX),
+            expect_u16(ABI::NetBSD as u16).map(|_| ABI::NetBSD),
+            expect_u16(ABI::Linux as u16).map(|_| ABI::Linux),
+            expect_u16(ABI::GNUHurd as u16).map(|_| ABI::GNUHurd),
+            expect_u16(ABI::Solaris as u16).map(|_| ABI::Solaris),
+            expect_u16(ABI::AIX as u16).map(|_| ABI::AIX),
+            expect_u16(ABI::IRIX as u16).map(|_| ABI::IRIX),
+            expect_u16(ABI::FreeBSD as u16).map(|_| ABI::FreeBSD),
+            expect_u16(ABI::Tru64 as u16).map(|_| ABI::Tru64),
+            expect_u16(ABI::Novell as u16).map(|_| ABI::Novell),
+            expect_u16(ABI::OpenBSD as u16).map(|_| ABI::OpenBSD),
+            expect_u16(ABI::OpenVMS as u16).map(|_| ABI::OpenVMS),
+            expect_u16(ABI::NonStop as u16).map(|_| ABI::NonStop),
+            expect_u16(ABI::Aros as u16).map(|_| ABI::Aros),
+            expect_u16(ABI::Fenix as u16).map(|_| ABI::Fenix),
+            expect_u16(ABI::CloudABI as u16).map(|_| ABI::CloudABI),
+            expect_u16(ABI::OpenVOS as u16).map(|_| ABI::OpenVOS),
+        ])
+        .parse(input)
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
 pub enum Type {
-    None,
-    Rel,
-    Exec,
-    Dyn,
-    Core,
+    None = 0x00,
+    Rel = 0x01,
+    Exec = 0x02,
+    Dyn = 0x03,
+    Core = 0x04,
+    LOOS = 0xFE00,
+    HIOS = 0xFEFF,
+    LOPROC = 0xFF00,
+    HIPROC = 0xFFFF,
+}
+
+struct TypeParser;
+
+impl<'a> parcel::Parser<'a, &'a [u8], Type> for TypeParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Type> {
+        parcel::one_of(vec![
+            expect_u16(Type::None as u16).map(|_| Type::None),
+            expect_u16(Type::Rel as u16).map(|_| Type::Rel),
+            expect_u16(Type::Exec as u16).map(|_| Type::Exec),
+            expect_u16(Type::Dyn as u16).map(|_| Type::Dyn),
+            expect_u16(Type::Core as u16).map(|_| Type::Core),
+            expect_u16(Type::LOOS as u16).map(|_| Type::LOOS),
+            expect_u16(Type::HIOS as u16).map(|_| Type::HIOS),
+            expect_u16(Type::LOPROC as u16).map(|_| Type::LOPROC),
+            expect_u16(Type::HIPROC as u16).map(|_| Type::HIPROC),
+        ])
+        .parse(input)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
 pub enum Machine {
-    X86,
-    X86_64,
+    None = 0x00,
+    M32 = 0x01,
+    SPARC = 0x02,
+    X386 = 0x03,
+    M68k = 0x04,
+    M88k = 0x05,
+    IntelMCU = 0x06,
+    Intel80860 = 0x07,
+    MIPS = 0x08,
+    S370 = 0x09,
+    MIPSRS3LE = 0x0A,
+    PARISC = 0x0E,
+    I960 = 0x13,
+    PPC = 0x14,
+    PPC64 = 0x15,
+    S390 = 0x16,
+    V800 = 0x24,
+    FR20 = 0x25,
+    RH32 = 0x26,
+    RCE = 0x27,
+    ARM = 0x28,
+    Alpha = 0x29,
+    SH = 0x2A,
+    SPARCV9 = 0x2B,
+    Tricore = 0x2C,
+    ARC = 0x2D,
+    H8300 = 0x2E,
+    H8_300H = 0x2F,
+    H8s = 0x30,
+    H8500 = 0x31,
+    IA64 = 0x32,
+    MIPSX = 0x33,
+    Coldfire = 0x34,
+    M68HC12 = 0x35,
+    MMA = 0x36,
+    PCP = 0x37,
+    NCPU = 0x38,
+    NDR1 = 0x39,
+    Starcore = 0x3A,
+    ME16 = 0x3B,
+    ST100 = 0x3C,
+    TinyJ = 0x3D,
+    X86_64 = 0x3E,
+    S320C600 = 0x8C,
+    AARCH64 = 0xB7,
+    RISCV = 0xF3,
+    BPF = 0xF7,
+    WDC65C817 = 0x101,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EntryPoint(pub u64);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ELFHeader {
+pub struct FileHeader {
     class: Class,
     endianness: Endianness,
     version: Version,
@@ -94,10 +232,10 @@ pub struct ELFHeader {
     entry_point: EntryPoint,
 }
 
-pub struct ELFParser;
+pub struct FileHeaderParser;
 
-impl<'a> parcel::Parser<'a, &'a [u8], ELFHeader> for ELFParser {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], ELFHeader> {
+impl<'a> parcel::Parser<'a, &'a [u8], FileHeader> for FileHeaderParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], FileHeader> {
         parcel::right(parcel::join(
             expect_bytes(&[0x7f, 0x45, 0x4c, 0x46]),
             parcel::join(
@@ -107,13 +245,13 @@ impl<'a> parcel::Parser<'a, &'a [u8], ELFHeader> for ELFParser {
         ))
         // skip padding
         .and_then(|last| parcel::take_n(parcel::parsers::byte::any_byte(), 8).map(move |_| last))
-        .map(|((class, endianness), (version, abi))| ELFHeader {
+        .map(|((class, endianness), (version, abi))| FileHeader {
             class,
             endianness,
             version,
             abi,
             r#type: Type::None,
-            machine: Machine::X86,
+            machine: Machine::X86_64,
             vers: version,
             entry_point: EntryPoint(0),
         })
@@ -134,6 +272,18 @@ pub fn expect_bytes<'a>(expected: &'static [u8]) -> impl Parser<'a, &'a [u8], Ve
     }
 }
 
+pub fn expect_u16<'a>(expected: u16) -> impl Parser<'a, &'a [u8], u16> {
+    move |input: &'a [u8]| {
+        let preparse_input = input;
+        let next: Vec<u8> = input.iter().take(2).copied().collect();
+        if next == expected.to_ne_bytes() {
+            Ok(MatchStatus::Match((&input[2..], expected)))
+        } else {
+            Ok(MatchStatus::NoMatch(preparse_input))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,8 +295,8 @@ mod tests {
         ];
 
         assert_eq!(
-            ELFParser.parse(&input).unwrap().unwrap(),
-            ELFHeader {
+            FileHeaderParser.parse(&input).unwrap().unwrap(),
+            FileHeader {
                 class: Class::ThirtyTwo,
                 endianness: Endianness::Little,
                 version: Version::One,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@ use parcel::parsers::byte::expect_byte;
 use parcel::prelude::v1::*;
 
 // Type Metadata
-type ELF32Addr = u32;
-type ELF64Addr = u64;
+type Elf32Addr = u32;
+type Elf64Addr = u64;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum FileErr {
@@ -18,86 +18,86 @@ impl std::fmt::Debug for FileErr {
     }
 }
 
-/// EIClass contains a 1-byte value representing whether a type is 32 or 64-bit
+/// EiClass contains a 1-byte value representing whether a type is 32 or 64-bit
 /// respectively.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum EIClass {
+pub enum EiClass {
     ThirtyTwoBit = 0x01,
     SixtyFourBit = 0x02,
 }
 
-impl From<EIClass> for u8 {
-    fn from(src: EIClass) -> Self {
+impl From<EiClass> for u8 {
+    fn from(src: EiClass) -> Self {
         src as u8
     }
 }
 
-struct EIClassParser;
+struct EiClassParser;
 
-impl<'a> parcel::Parser<'a, &'a [u8], EIClass> for EIClassParser {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIClass> {
+impl<'a> parcel::Parser<'a, &'a [u8], EiClass> for EiClassParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EiClass> {
         parcel::one_of(vec![
-            expect_byte(EIClass::ThirtyTwoBit as u8).map(|_| EIClass::ThirtyTwoBit),
-            expect_byte(EIClass::SixtyFourBit as u8).map(|_| EIClass::SixtyFourBit),
+            expect_byte(EiClass::ThirtyTwoBit as u8).map(|_| EiClass::ThirtyTwoBit),
+            expect_byte(EiClass::SixtyFourBit as u8).map(|_| EiClass::SixtyFourBit),
         ])
         .parse(input)
     }
 }
 
-/// EIData stores a 1-byte value representing if the header is in little-endian
+/// EiData stores a 1-byte value representing if the header is in little-endian
 /// or big-endian format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum EIData {
+pub enum EiData {
     Little = 0x01,
     Big = 0x02,
 }
 
-impl From<EIData> for u8 {
-    fn from(src: EIData) -> Self {
+impl From<EiData> for u8 {
+    fn from(src: EiData) -> Self {
         src as u8
     }
 }
 
-struct EIDataParser;
+struct EiDataParser;
 
-impl<'a> parcel::Parser<'a, &'a [u8], EIData> for EIDataParser {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIData> {
+impl<'a> parcel::Parser<'a, &'a [u8], EiData> for EiDataParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EiData> {
         parcel::one_of(vec![
-            expect_byte(EIData::Little as u8).map(|_| EIData::Little),
-            expect_byte(EIData::Big as u8).map(|_| EIData::Big),
+            expect_byte(EiData::Little as u8).map(|_| EiData::Little),
+            expect_byte(EiData::Big as u8).map(|_| EiData::Big),
         ])
         .parse(input)
     }
 }
 
-/// EIVersion represents which version of ELF header is being used.
+/// EiVersion represents which version of ELF header is being used.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum EIVersion {
+pub enum EiVersion {
     One = 1,
 }
 
-impl From<EIVersion> for u8 {
-    fn from(src: EIVersion) -> Self {
+impl From<EiVersion> for u8 {
+    fn from(src: EiVersion) -> Self {
         src as u8
     }
 }
-struct EIVersionParser;
+struct EiVersionParser;
 
-impl<'a> parcel::Parser<'a, &'a [u8], EIVersion> for EIVersionParser {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIVersion> {
-        expect_byte(EIVersion::One as u8)
-            .map(|_| EIVersion::One)
+impl<'a> parcel::Parser<'a, &'a [u8], EiVersion> for EiVersionParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EiVersion> {
+        expect_byte(EiVersion::One as u8)
+            .map(|_| EiVersion::One)
             .parse(input)
     }
 }
 
-/// EIOSABI represents the target systems ABI.
+/// EiOSABI represents the target systems ABI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum EIOSABI {
+pub enum EiOSABI {
     SysV = 0x00,
     HPUX = 0x01,
     NetBSD = 0x02,
@@ -118,35 +118,35 @@ pub enum EIOSABI {
     OpenVOS = 0x12,
 }
 
-impl From<EIOSABI> for u8 {
-    fn from(src: EIOSABI) -> Self {
+impl From<EiOSABI> for u8 {
+    fn from(src: EiOSABI) -> Self {
         src as u8
     }
 }
 
-struct EIOSABIParser;
+struct EiOSABIParser;
 
-impl<'a> parcel::Parser<'a, &'a [u8], EIOSABI> for EIOSABIParser {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIOSABI> {
+impl<'a> parcel::Parser<'a, &'a [u8], EiOSABI> for EiOSABIParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EiOSABI> {
         parcel::one_of(vec![
-            expect_byte(EIOSABI::SysV as u8).map(|_| EIOSABI::SysV),
-            expect_byte(EIOSABI::HPUX as u8).map(|_| EIOSABI::HPUX),
-            expect_byte(EIOSABI::NetBSD as u8).map(|_| EIOSABI::NetBSD),
-            expect_byte(EIOSABI::Linux as u8).map(|_| EIOSABI::Linux),
-            expect_byte(EIOSABI::GNUHurd as u8).map(|_| EIOSABI::GNUHurd),
-            expect_byte(EIOSABI::Solaris as u8).map(|_| EIOSABI::Solaris),
-            expect_byte(EIOSABI::AIX as u8).map(|_| EIOSABI::AIX),
-            expect_byte(EIOSABI::IRIX as u8).map(|_| EIOSABI::IRIX),
-            expect_byte(EIOSABI::FreeBSD as u8).map(|_| EIOSABI::FreeBSD),
-            expect_byte(EIOSABI::Tru64 as u8).map(|_| EIOSABI::Tru64),
-            expect_byte(EIOSABI::Novell as u8).map(|_| EIOSABI::Novell),
-            expect_byte(EIOSABI::OpenBSD as u8).map(|_| EIOSABI::OpenBSD),
-            expect_byte(EIOSABI::OpenVMS as u8).map(|_| EIOSABI::OpenVMS),
-            expect_byte(EIOSABI::NonStop as u8).map(|_| EIOSABI::NonStop),
-            expect_byte(EIOSABI::Aros as u8).map(|_| EIOSABI::Aros),
-            expect_byte(EIOSABI::Fenix as u8).map(|_| EIOSABI::Fenix),
-            expect_byte(EIOSABI::CloudABI as u8).map(|_| EIOSABI::CloudABI),
-            expect_byte(EIOSABI::OpenVOS as u8).map(|_| EIOSABI::OpenVOS),
+            expect_byte(EiOSABI::SysV as u8).map(|_| EiOSABI::SysV),
+            expect_byte(EiOSABI::HPUX as u8).map(|_| EiOSABI::HPUX),
+            expect_byte(EiOSABI::NetBSD as u8).map(|_| EiOSABI::NetBSD),
+            expect_byte(EiOSABI::Linux as u8).map(|_| EiOSABI::Linux),
+            expect_byte(EiOSABI::GNUHurd as u8).map(|_| EiOSABI::GNUHurd),
+            expect_byte(EiOSABI::Solaris as u8).map(|_| EiOSABI::Solaris),
+            expect_byte(EiOSABI::AIX as u8).map(|_| EiOSABI::AIX),
+            expect_byte(EiOSABI::IRIX as u8).map(|_| EiOSABI::IRIX),
+            expect_byte(EiOSABI::FreeBSD as u8).map(|_| EiOSABI::FreeBSD),
+            expect_byte(EiOSABI::Tru64 as u8).map(|_| EiOSABI::Tru64),
+            expect_byte(EiOSABI::Novell as u8).map(|_| EiOSABI::Novell),
+            expect_byte(EiOSABI::OpenBSD as u8).map(|_| EiOSABI::OpenBSD),
+            expect_byte(EiOSABI::OpenVMS as u8).map(|_| EiOSABI::OpenVMS),
+            expect_byte(EiOSABI::NonStop as u8).map(|_| EiOSABI::NonStop),
+            expect_byte(EiOSABI::Aros as u8).map(|_| EiOSABI::Aros),
+            expect_byte(EiOSABI::Fenix as u8).map(|_| EiOSABI::Fenix),
+            expect_byte(EiOSABI::CloudABI as u8).map(|_| EiOSABI::CloudABI),
+            expect_byte(EiOSABI::OpenVOS as u8).map(|_| EiOSABI::OpenVOS),
         ])
         .parse(input)
     }
@@ -198,7 +198,7 @@ impl From<Type> for u16 {
     }
 }
 
-struct TypeParser(EIData);
+struct TypeParser(EiData);
 
 impl<'a> parcel::Parser<'a, &'a [u8], Type> for TypeParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Type> {
@@ -277,7 +277,7 @@ impl From<Machine> for u16 {
     }
 }
 
-struct MachineParser(EIData);
+struct MachineParser(EiData);
 
 impl<'a> parcel::Parser<'a, &'a [u8], Machine> for MachineParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Machine> {
@@ -293,8 +293,8 @@ impl<'a> parcel::Parser<'a, &'a [u8], Machine> for MachineParser {
             .try_into()
             .map(|mcode| {
                 let val = match endianness {
-                    EIData::Little => u16::from_le_bytes(mcode),
-                    EIData::Big => u16::from_be_bytes(mcode),
+                    EiData::Little => u16::from_le_bytes(mcode),
+                    EiData::Big => u16::from_be_bytes(mcode),
                 };
                 match val {
                     0x00 => Some(Machine::None),
@@ -342,7 +342,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], Machine> for MachineParser {
                     0x3e => Some(Machine::X86_64),
                     0x8C => Some(Machine::S320C600),
                     0xB9 => Some(Machine::AARCH64),
-                    0xFa => Some(Machine::RISCV),
+                    0xFA => Some(Machine::RISCV),
                     0xFB => Some(Machine::BPF),
                     0x101 => Some(Machine::WDC65C817),
                     _ => None,
@@ -367,7 +367,7 @@ impl From<Version> for u32 {
     }
 }
 
-struct VersionParser(EIData);
+struct VersionParser(EiData);
 
 impl<'a> parcel::Parser<'a, &'a [u8], Version> for VersionParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Version> {
@@ -376,30 +376,30 @@ impl<'a> parcel::Parser<'a, &'a [u8], Version> for VersionParser {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-/// EIIdent defines the elf identification fields that define whether the
+/// EiIdent defines the elf identification fields that define whether the
 /// address size, versions and abi of the file.
-pub struct EIIdent {
-    pub ei_class: EIClass,
-    pub ei_data: EIData,
-    pub ei_version: EIVersion,
-    pub ei_osabi: EIOSABI,
+pub struct EiIdent {
+    pub ei_class: EiClass,
+    pub ei_data: EiData,
+    pub ei_version: EiVersion,
+    pub ei_osabi: EiOSABI,
     pub ei_abiversion: EIABIVersion,
 }
 
-/// EIIdentParser defines a parser for parsing a raw bitstream into an EIIdent.
-struct EIIdentParser;
+/// EiIdentParser defines a parser for parsing a raw bitstream into an EiIdent.
+struct EiIdentParser;
 
-impl<'a> parcel::Parser<'a, &'a [u8], EIIdent> for EIIdentParser {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIIdent> {
+impl<'a> parcel::Parser<'a, &'a [u8], EiIdent> for EiIdentParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EiIdent> {
         parcel::right(parcel::join(
             expect_bytes(&[0x7f, 0x45, 0x4c, 0x46]),
             parcel::join(
-                EIClassParser,
+                EiClassParser,
                 parcel::join(
-                    EIDataParser,
+                    EiDataParser,
                     parcel::join(
-                        EIVersionParser,
-                        parcel::join(EIOSABIParser, EIABIVersionParser),
+                        EiVersionParser,
+                        parcel::join(EiOSABIParser, EIABIVersionParser),
                     ),
                 ),
             )
@@ -409,7 +409,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIIdent> for EIIdentParser {
             }),
         ))
         .map(
-            |(ei_class, (ei_data, (ei_version, (ei_osabi, ei_abiversion))))| EIIdent {
+            |(ei_class, (ei_data, (ei_version, (ei_osabi, ei_abiversion))))| EiIdent {
                 ei_class,
                 ei_data,
                 ei_version,
@@ -426,7 +426,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIIdent> for EIIdentParser {
 /// information along with sizing, architechture and additional metadata about
 /// other ELF headers.
 pub struct FileHeader<AddrWidth> {
-    ei_ident: EIIdent,
+    ei_ident: EiIdent,
     r#type: Type,
     machine: Machine,
     version: Version,
@@ -468,8 +468,8 @@ impl FileHeaderParser<u64> {
 impl<A> FileHeaderParser<A> {
     /// identifier parses the elf magic bytes and class, returning the class if
     /// the elf file has a valid preamble.
-    pub fn identifier(input: &[u8]) -> Result<EIIdent, FileErr> {
-        EIIdentParser
+    pub fn identifier(input: &[u8]) -> Result<EiIdent, FileErr> {
+        EiIdentParser
             .parse(input)
             .map(|ms| match ms {
                 MatchStatus::Match((_, ei_ident)) => Some(ei_ident),
@@ -480,8 +480,8 @@ impl<A> FileHeaderParser<A> {
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [u8], FileHeader<ELF32Addr>> for FileHeaderParser<ELF32Addr> {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], FileHeader<ELF32Addr>> {
+impl<'a> parcel::Parser<'a, &'a [u8], FileHeader<Elf32Addr>> for FileHeaderParser<Elf32Addr> {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], FileHeader<Elf32Addr>> {
         let ei_ident = Self::identifier(input).map_err(|e| format!("{:?}", e))?;
 
         parcel::join(
@@ -536,8 +536,8 @@ impl<'a> parcel::Parser<'a, &'a [u8], FileHeader<ELF32Addr>> for FileHeaderParse
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [u8], FileHeader<ELF64Addr>> for FileHeaderParser<ELF64Addr> {
-    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], FileHeader<ELF64Addr>> {
+impl<'a> parcel::Parser<'a, &'a [u8], FileHeader<Elf64Addr>> for FileHeaderParser<Elf64Addr> {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], FileHeader<Elf64Addr>> {
         let ei_ident = Self::identifier(input).map_err(|e| format!("{:?}", e))?;
 
         parcel::join(
@@ -611,7 +611,7 @@ fn expect_bytes<'a>(expected: &'static [u8]) -> impl Parser<'a, &'a [u8], Vec<u8
 /// Matches a single provided static u16, returning a match if the next
 /// two bytes in the array match the expected u16. Otherwise, a `NoMatch` is
 /// returned.
-fn expect_u16<'a>(endianness: EIData, expected: u16) -> impl Parser<'a, &'a [u8], u16> {
+fn expect_u16<'a>(endianness: EiData, expected: u16) -> impl Parser<'a, &'a [u8], u16> {
     move |input: &'a [u8]| {
         let preparse_input = input;
         match match_u16(endianness).parse(input) {
@@ -626,7 +626,7 @@ fn expect_u16<'a>(endianness: EIData, expected: u16) -> impl Parser<'a, &'a [u8]
 /// Matches a single provided static u32, returning a match if the next
 /// four bytes in the array match the expected u32. Otherwise, a `NoMatch` is
 /// returned.
-fn expect_u32<'a>(endianness: EIData, expected: u32) -> impl Parser<'a, &'a [u8], u32> {
+fn expect_u32<'a>(endianness: EiData, expected: u32) -> impl Parser<'a, &'a [u8], u32> {
     move |input: &'a [u8]| {
         let preparse_input = input;
         match match_u32(endianness).parse(input) {
@@ -639,45 +639,45 @@ fn expect_u32<'a>(endianness: EIData, expected: u32) -> impl Parser<'a, &'a [u8]
 }
 
 /// Matches any given u16 by endianness returning a corresponding u16 value.
-fn match_u16<'a>(endianness: EIData) -> impl Parser<'a, &'a [u8], u16> {
+fn match_u16<'a>(endianness: EiData) -> impl Parser<'a, &'a [u8], u16> {
     use parcel::parsers::byte::any_byte;
     use std::convert::TryInto;
 
     parcel::take_n(any_byte(), 2).map(move |b| {
         b.try_into()
             .map(|ep| match endianness {
-                EIData::Little => u16::from_le_bytes(ep),
-                EIData::Big => u16::from_be_bytes(ep),
+                EiData::Little => u16::from_le_bytes(ep),
+                EiData::Big => u16::from_be_bytes(ep),
             })
             .unwrap()
     })
 }
 
 /// Matches any given u32 by endianness returning a corresponding u32 value.
-fn match_u32<'a>(endianness: EIData) -> impl Parser<'a, &'a [u8], u32> {
+fn match_u32<'a>(endianness: EiData) -> impl Parser<'a, &'a [u8], u32> {
     use parcel::parsers::byte::any_byte;
     use std::convert::TryInto;
 
     parcel::take_n(any_byte(), 4).map(move |b| {
         b.try_into()
             .map(|ep| match endianness {
-                EIData::Little => u32::from_le_bytes(ep),
-                EIData::Big => u32::from_be_bytes(ep),
+                EiData::Little => u32::from_le_bytes(ep),
+                EiData::Big => u32::from_be_bytes(ep),
             })
             .unwrap()
     })
 }
 
 /// Matches any given u64 by endianness returning a corresponding u64 value.
-fn match_u64<'a>(endianness: EIData) -> impl Parser<'a, &'a [u8], u64> {
+fn match_u64<'a>(endianness: EiData) -> impl Parser<'a, &'a [u8], u64> {
     use parcel::parsers::byte::any_byte;
     use std::convert::TryInto;
 
     parcel::take_n(any_byte(), 8).map(move |b| {
         b.try_into()
             .map(|ep| match endianness {
-                EIData::Little => u64::from_le_bytes(ep),
-                EIData::Big => u64::from_be_bytes(ep),
+                EiData::Little => u64::from_le_bytes(ep),
+                EiData::Big => u64::from_be_bytes(ep),
             })
             .unwrap()
     })
@@ -700,16 +700,16 @@ mod tests {
         let invalid_input = [0xff, 0xff, 0xff, 0xff, 0xff];
 
         assert_eq!(
-            Ok(EIClass::ThirtyTwoBit),
-            FileHeaderParser::<ELF32Addr>::identifier(&thirty_two_bit_input)
+            Ok(EiClass::ThirtyTwoBit),
+            FileHeaderParser::<Elf32Addr>::identifier(&thirty_two_bit_input)
                 .map(|ident| ident.ei_class)
         );
         assert_eq!(
-            Ok(EIClass::SixtyFourBit),
-            FileHeaderParser::<ELF64Addr>::identifier(&sixty_four_bit_input)
+            Ok(EiClass::SixtyFourBit),
+            FileHeaderParser::<Elf64Addr>::identifier(&sixty_four_bit_input)
                 .map(|ident| ident.ei_class)
         );
-        assert!(FileHeaderParser::<ELF64Addr>::identifier(&invalid_input).is_err());
+        assert!(FileHeaderParser::<Elf64Addr>::identifier(&invalid_input).is_err());
     }
 
     #[test]
@@ -738,16 +738,16 @@ mod tests {
         ];
 
         assert_eq!(
-            FileHeaderParser::<ELF32Addr>::new()
+            FileHeaderParser::<Elf32Addr>::new()
                 .parse(&input)
                 .unwrap()
                 .unwrap(),
             FileHeader::<u32> {
-                ei_ident: EIIdent {
-                    ei_class: EIClass::ThirtyTwoBit,
-                    ei_data: EIData::Little,
-                    ei_version: EIVersion::One,
-                    ei_osabi: EIOSABI::SysV,
+                ei_ident: EiIdent {
+                    ei_class: EiClass::ThirtyTwoBit,
+                    ei_data: EiData::Little,
+                    ei_version: EiVersion::One,
+                    ei_osabi: EiOSABI::SysV,
                     ei_abiversion: EIABIVersion::One,
                 },
                 r#type: Type::None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], Machine> for MachineParser {
             .try_into()
             .unwrap();
 
-        match u16::from_be_bytes(mcode) {
+        match u16::from_ne_bytes(mcode) {
             0x0000 => Some(Machine::None),
             0x0003 => Some(Machine::X386),
             0x003e => Some(Machine::X86_64),
@@ -467,7 +467,7 @@ mod tests {
     fn parse_known_good_header() {
         let input = [
             0x7f, 0x45, 0x4c, 0x46, 0x01, 0x01, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
+            0x00, 0x00, 0x00, 0x00, 0x03, 0x00,
         ];
 
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,11 @@ struct ClassParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], Class> for ClassParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Class> {
-        parcel::parsers::byte::expect_byte(0x01)
-            .map(|_| Class::ThirtyTwo)
-            .or(|| parcel::parsers::byte::expect_byte(0x02).map(|_| Class::SixtyFour))
-            .parse(input)
+        parcel::one_of(vec![
+            parcel::parsers::byte::expect_byte(0x01).map(|_| Class::ThirtyTwo),
+            parcel::parsers::byte::expect_byte(0x02).map(|_| Class::SixtyFour),
+        ])
+        .parse(input)
     }
 }
 
@@ -221,6 +222,70 @@ pub enum Machine {
     RISCV = 0xF3,
     BPF = 0xF7,
     WDC65C817 = 0x101,
+}
+
+impl From<Machine> for u16 {
+    fn from(src: Machine) -> Self {
+        src as u16
+    }
+}
+
+struct MachineParser;
+
+impl<'a> parcel::Parser<'a, &'a [u8], Machine> for MachineParser {
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Machine> {
+        parcel::one_of(vec![
+            expect_u16(Machine::None as u16).map(|_| Machine::None),
+            expect_u16(Machine::M32 as u16).map(|_| Machine::M32),
+            expect_u16(Machine::SPARC as u16).map(|_| Machine::SPARC),
+            expect_u16(Machine::X386 as u16).map(|_| Machine::X386),
+            expect_u16(Machine::M68k as u16).map(|_| Machine::M68k),
+            expect_u16(Machine::M88k as u16).map(|_| Machine::M88k),
+            expect_u16(Machine::IntelMCU as u16).map(|_| Machine::IntelMCU),
+            expect_u16(Machine::Intel80860 as u16).map(|_| Machine::Intel80860),
+            expect_u16(Machine::MIPS as u16).map(|_| Machine::MIPS),
+            expect_u16(Machine::S370 as u16).map(|_| Machine::S370),
+            expect_u16(Machine::MIPSRS3LE as u16).map(|_| Machine::MIPSRS3LE),
+            expect_u16(Machine::PARISC as u16).map(|_| Machine::PARISC),
+            expect_u16(Machine::I960 as u16).map(|_| Machine::I960),
+            expect_u16(Machine::PPC as u16).map(|_| Machine::PPC),
+            expect_u16(Machine::PPC64 as u16).map(|_| Machine::PPC64),
+            expect_u16(Machine::S390 as u16).map(|_| Machine::S390),
+            expect_u16(Machine::V800 as u16).map(|_| Machine::V800),
+            expect_u16(Machine::FR20 as u16).map(|_| Machine::FR20),
+            expect_u16(Machine::RH32 as u16).map(|_| Machine::RH32),
+            expect_u16(Machine::RCE as u16).map(|_| Machine::RCE),
+            expect_u16(Machine::ARM as u16).map(|_| Machine::ARM),
+            expect_u16(Machine::Alpha as u16).map(|_| Machine::Alpha),
+            expect_u16(Machine::SH as u16).map(|_| Machine::SH),
+            expect_u16(Machine::SPARCV9 as u16).map(|_| Machine::SPARCV9),
+            expect_u16(Machine::Tricore as u16).map(|_| Machine::Tricore),
+            expect_u16(Machine::ARC as u16).map(|_| Machine::ARC),
+            expect_u16(Machine::H8300 as u16).map(|_| Machine::H8300),
+            expect_u16(Machine::H8_300H as u16).map(|_| Machine::H8_300H),
+            expect_u16(Machine::H8s as u16).map(|_| Machine::H8s),
+            expect_u16(Machine::H8500 as u16).map(|_| Machine::H8500),
+            expect_u16(Machine::IA64 as u16).map(|_| Machine::IA64),
+            expect_u16(Machine::MIPSX as u16).map(|_| Machine::MIPSX),
+            expect_u16(Machine::Coldfire as u16).map(|_| Machine::Coldfire),
+            expect_u16(Machine::M68HC12 as u16).map(|_| Machine::M68HC12),
+            expect_u16(Machine::MMA as u16).map(|_| Machine::MMA),
+            expect_u16(Machine::PCP as u16).map(|_| Machine::PCP),
+            expect_u16(Machine::NCPU as u16).map(|_| Machine::NCPU),
+            expect_u16(Machine::NDR1 as u16).map(|_| Machine::NDR1),
+            expect_u16(Machine::Starcore as u16).map(|_| Machine::Starcore),
+            expect_u16(Machine::ME16 as u16).map(|_| Machine::ME16),
+            expect_u16(Machine::ST100 as u16).map(|_| Machine::ST100),
+            expect_u16(Machine::TinyJ as u16).map(|_| Machine::TinyJ),
+            expect_u16(Machine::X86_64 as u16).map(|_| Machine::X86_64),
+            expect_u16(Machine::S320C600 as u16).map(|_| Machine::S320C600),
+            expect_u16(Machine::AARCH64 as u16).map(|_| Machine::AARCH64),
+            expect_u16(Machine::RISCV as u16).map(|_| Machine::RISCV),
+            expect_u16(Machine::BPF as u16).map(|_| Machine::BPF),
+            expect_u16(Machine::WDC65C817 as u16).map(|_| Machine::WDC65C817),
+        ])
+        .parse(input)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,12 +270,13 @@ impl From<Machine> for u16 {
     }
 }
 
-struct MachineParser;
+struct MachineParser(EIData);
 
 impl<'a> parcel::Parser<'a, &'a [u8], Machine> for MachineParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], Machine> {
         use std::convert::TryInto;
         let preparse_input = input;
+        let endianness = self.0;
 
         input
             .iter()
@@ -283,56 +284,62 @@ impl<'a> parcel::Parser<'a, &'a [u8], Machine> for MachineParser {
             .copied()
             .collect::<Vec<u8>>()
             .try_into()
-            .map(|mcode| match u16::from_ne_bytes(mcode) {
-                0x00 => Some(Machine::None),
-                0x01 => Some(Machine::M32),
-                0x02 => Some(Machine::SPARC),
-                0x03 => Some(Machine::X386),
-                0x04 => Some(Machine::M68k),
-                0x05 => Some(Machine::M88k),
-                0x06 => Some(Machine::IntelMCU),
-                0x07 => Some(Machine::Intel80860),
-                0x08 => Some(Machine::MIPS),
-                0x09 => Some(Machine::S370),
-                0x0A => Some(Machine::MIPSRS3LE),
-                0x0E => Some(Machine::PARISC),
-                0x13 => Some(Machine::I960),
-                0x14 => Some(Machine::PPC),
-                0x15 => Some(Machine::PPC64),
-                0x16 => Some(Machine::S390),
-                0x24 => Some(Machine::V800),
-                0x25 => Some(Machine::FR20),
-                0x26 => Some(Machine::RH32),
-                0x27 => Some(Machine::RCE),
-                0x28 => Some(Machine::ARM),
-                0x29 => Some(Machine::Alpha),
-                0x2A => Some(Machine::SH),
-                0x2B => Some(Machine::SPARCV9),
-                0x2C => Some(Machine::Tricore),
-                0x2D => Some(Machine::ARC),
-                0x2E => Some(Machine::H8300),
-                0x2F => Some(Machine::H8_300H),
-                0x30 => Some(Machine::H8s),
-                0x31 => Some(Machine::H8500),
-                0x32 => Some(Machine::IA64),
-                0x33 => Some(Machine::MIPSX),
-                0x34 => Some(Machine::Coldfire),
-                0x35 => Some(Machine::M68HC12),
-                0x36 => Some(Machine::MMA),
-                0x37 => Some(Machine::PCP),
-                0x38 => Some(Machine::NCPU),
-                0x39 => Some(Machine::NDR1),
-                0x3a => Some(Machine::Starcore),
-                0x3B => Some(Machine::ME16),
-                0x3C => Some(Machine::ST100),
-                0x3D => Some(Machine::TinyJ),
-                0x3e => Some(Machine::X86_64),
-                0x8C => Some(Machine::S320C600),
-                0xB9 => Some(Machine::AARCH64),
-                0xFa => Some(Machine::RISCV),
-                0xFB => Some(Machine::BPF),
-                0x101 => Some(Machine::WDC65C817),
-                _ => None,
+            .map(|mcode| {
+                let val = match endianness {
+                    EIData::Little => u16::from_le_bytes(mcode),
+                    EIData::Big => u16::from_be_bytes(mcode),
+                };
+                match val {
+                    0x00 => Some(Machine::None),
+                    0x01 => Some(Machine::M32),
+                    0x02 => Some(Machine::SPARC),
+                    0x03 => Some(Machine::X386),
+                    0x04 => Some(Machine::M68k),
+                    0x05 => Some(Machine::M88k),
+                    0x06 => Some(Machine::IntelMCU),
+                    0x07 => Some(Machine::Intel80860),
+                    0x08 => Some(Machine::MIPS),
+                    0x09 => Some(Machine::S370),
+                    0x0A => Some(Machine::MIPSRS3LE),
+                    0x0E => Some(Machine::PARISC),
+                    0x13 => Some(Machine::I960),
+                    0x14 => Some(Machine::PPC),
+                    0x15 => Some(Machine::PPC64),
+                    0x16 => Some(Machine::S390),
+                    0x24 => Some(Machine::V800),
+                    0x25 => Some(Machine::FR20),
+                    0x26 => Some(Machine::RH32),
+                    0x27 => Some(Machine::RCE),
+                    0x28 => Some(Machine::ARM),
+                    0x29 => Some(Machine::Alpha),
+                    0x2A => Some(Machine::SH),
+                    0x2B => Some(Machine::SPARCV9),
+                    0x2C => Some(Machine::Tricore),
+                    0x2D => Some(Machine::ARC),
+                    0x2E => Some(Machine::H8300),
+                    0x2F => Some(Machine::H8_300H),
+                    0x30 => Some(Machine::H8s),
+                    0x31 => Some(Machine::H8500),
+                    0x32 => Some(Machine::IA64),
+                    0x33 => Some(Machine::MIPSX),
+                    0x34 => Some(Machine::Coldfire),
+                    0x35 => Some(Machine::M68HC12),
+                    0x36 => Some(Machine::MMA),
+                    0x37 => Some(Machine::PCP),
+                    0x38 => Some(Machine::NCPU),
+                    0x39 => Some(Machine::NDR1),
+                    0x3a => Some(Machine::Starcore),
+                    0x3B => Some(Machine::ME16),
+                    0x3C => Some(Machine::ST100),
+                    0x3D => Some(Machine::TinyJ),
+                    0x3e => Some(Machine::X86_64),
+                    0x8C => Some(Machine::S320C600),
+                    0xB9 => Some(Machine::AARCH64),
+                    0xFa => Some(Machine::RISCV),
+                    0xFB => Some(Machine::BPF),
+                    0x101 => Some(Machine::WDC65C817),
+                    _ => None,
+                }
             })
             .unwrap()
             .map_or(Ok(MatchStatus::NoMatch(preparse_input)), |m| {
@@ -473,7 +480,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], FileHeader<ELF32Addr>> for FileHeaderParse
         parcel::join(
             TypeParser(ei_ident.ei_data),
             parcel::join(
-                MachineParser,
+                MachineParser(ei_ident.ei_data),
                 parcel::join(
                     VersionParser(ei_ident.ei_data),
                     parcel::join(
@@ -529,7 +536,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], FileHeader<ELF64Addr>> for FileHeaderParse
         parcel::join(
             TypeParser(ei_ident.ei_data),
             parcel::join(
-                MachineParser,
+                MachineParser(ei_ident.ei_data),
                 parcel::join(
                     VersionParser(ei_ident.ei_data),
                     parcel::join(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,8 +609,8 @@ fn expect_u16<'a>(endianness: EIData, expected: u16) -> impl Parser<'a, &'a [u8]
     }
 }
 
-/// Matches a single provided static u16, returning a match if the next
-/// two bytes in the array match the expected u16. Otherwise, a `NoMatch` is
+/// Matches a single provided static u32, returning a match if the next
+/// four bytes in the array match the expected u32. Otherwise, a `NoMatch` is
 /// returned.
 fn expect_u32<'a>(endianness: EIData, expected: u32) -> impl Parser<'a, &'a [u8], u32> {
     move |input: &'a [u8]| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ impl std::fmt::Debug for FileErr {
     }
 }
 
+/// EIClass contains a 1-byte value representing whether a type is 32 or 64-bit
+/// respectively.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum EIClass {
@@ -43,6 +45,8 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIClass> for EIClassParser {
     }
 }
 
+/// EIData stores a 1-byte value representing if the header is in little-endian
+/// or big-endian format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum EIData {
@@ -68,6 +72,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIData> for EIDataParser {
     }
 }
 
+/// EIVersion represents which version of ELF header is being used.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum EIVersion {
@@ -89,6 +94,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIVersion> for EIVersionParser {
     }
 }
 
+/// EIOSABI represents the target systems ABI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum EIOSABI {
@@ -146,6 +152,7 @@ impl<'a> parcel::Parser<'a, &'a [u8], EIOSABI> for EIOSABIParser {
     }
 }
 
+/// EIABIVersion represents the abi version and is often left null.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum EIABIVersion {
@@ -380,7 +387,7 @@ pub struct EIIdent {
 }
 
 /// EIIdentParser defines a parser for parsing a raw bitstream into an EIIdent.
-pub struct EIIdentParser;
+struct EIIdentParser;
 
 impl<'a> parcel::Parser<'a, &'a [u8], EIIdent> for EIIdentParser {
     fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], EIIdent> {
@@ -631,6 +638,7 @@ fn expect_u32<'a>(endianness: EIData, expected: u32) -> impl Parser<'a, &'a [u8]
     }
 }
 
+/// Matches any given u16 by endianness returning a corresponding u16 value.
 fn match_u16<'a>(endianness: EIData) -> impl Parser<'a, &'a [u8], u16> {
     use parcel::parsers::byte::any_byte;
     use std::convert::TryInto;
@@ -645,6 +653,7 @@ fn match_u16<'a>(endianness: EIData) -> impl Parser<'a, &'a [u8], u16> {
     })
 }
 
+/// Matches any given u32 by endianness returning a corresponding u32 value.
 fn match_u32<'a>(endianness: EIData) -> impl Parser<'a, &'a [u8], u32> {
     use parcel::parsers::byte::any_byte;
     use std::convert::TryInto;
@@ -660,6 +669,7 @@ fn match_u32<'a>(endianness: EIData) -> impl Parser<'a, &'a [u8], u32> {
     })
 }
 
+/// Matches any given u64 by endianness returning a corresponding u64 value.
 fn match_u64<'a>(endianness: EIData) -> impl Parser<'a, &'a [u8], u64> {
     use parcel::parsers::byte::any_byte;
     use std::convert::TryInto;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,8 @@ impl<'a> parcel::Parser<'a, &'a [u8], ELFHeader> for ELFParser {
                 parcel::join(VersionParser, ABIParser),
             ),
         ))
+        // skip padding
+        .and_then(|last| parcel::take_n(parcel::parsers::byte::any_byte(), 8).map(move |_| last))
         .map(|((class, endianness), (version, abi))| ELFHeader {
             class,
             endianness,
@@ -111,7 +113,10 @@ mod tests {
     use super::*;
     #[test]
     fn parse_known_good_header() {
-        let input = [0x7f, 0x45, 0x4c, 0x46, 0x01, 0x01, 0x01, 0x00];
+        let input = [
+            0x7f, 0x45, 0x4c, 0x46, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00,
+        ];
 
         assert_eq!(
             ELFParser.parse(&input).unwrap().unwrap(),


### PR DESCRIPTION
# Introduction
This PR introduces a first pass at defining FileHeaders for elf. Frankly... I hate it but this is enough for an initial implementation and It's enough to start working on refactory passes.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
