### PR TITLE
Section Header Parser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1193,6 +1193,40 @@ pub struct ProgramHeader64Bit {
 
 impl ProgramHeader for ProgramHeader64Bit {}
 
+/// ShType reprents all representable formats of the sh_type filed of a section
+/// header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ShType {
+    Null = 0x00,
+}
+
+/// ShFlags reprents all representable formats of the sh_flags filed of a
+/// section header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ShFlags {
+    Write = 0x01,
+}
+
+/// Section header represents a Elf Program header for the 32-bit arrangement.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SectionHeader<A>
+where
+    A: AddressWidth,
+{
+    pub sh_name: A,
+    pub sh_type: ShType,
+    pub sh_flags: ShFlags,
+    pub sh_addr: A,
+    pub sh_offset: A,
+    pub sh_size: A,
+    pub sh_link: u32,
+    pub sh_info: u32,
+    pub sh_addr_align: A,
+    pub sh_entsize: A,
+}
+
 /// ElfHeader captures the full ELF file header into a single struct along
 /// with the Identification information separated from the file header.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1213,27 +1213,31 @@ pub struct ShTypeParser<A> {
     address_width: std::marker::PhantomData<A>,
 }
 
-impl<'a> ShTypeParser<Elf32Addr> {
-    fn parse_type(
-        &self,
-        data: EiData,
-        input: &'a [u8],
-    ) -> parcel::ParseResult<'a, &'a [u8], ShType32Bit> {
+impl<'a, E> parcel::Parser<'a, &'a [u8], ShType32Bit> for ShTypeParser<E>
+where
+    EiData: From<E>,
+    E: DataEncoding + Default + 'static,
+{
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], ShType32Bit> {
+        let encoding = EiData::from(E::default());
+
         parcel::one_of(vec![
-            expect_u32(data, ShType32Bit::Null as u32).map(|_| ShType32Bit::Null)
+            expect_u64(encoding, ShType32Bit::Null as u64).map(|_| ShType32Bit::Null)
         ])
         .parse(input)
     }
 }
 
-impl<'a> ShTypeParser<Elf64Addr> {
-    fn parse_type(
-        &self,
-        data: EiData,
-        input: &'a [u8],
-    ) -> parcel::ParseResult<'a, &'a [u8], ShType64Bit> {
+impl<'a, E> parcel::Parser<'a, &'a [u8], ShType64Bit> for ShTypeParser<E>
+where
+    EiData: From<E>,
+    E: DataEncoding + Default + 'static,
+{
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], ShType64Bit> {
+        let encoding = EiData::from(E::default());
+
         parcel::one_of(vec![
-            expect_u64(data, ShType64Bit::Null as u64).map(|_| ShType64Bit::Null)
+            expect_u64(encoding, ShType64Bit::Null as u64).map(|_| ShType64Bit::Null)
         ])
         .parse(input)
     }
@@ -1245,6 +1249,48 @@ impl<'a> ShTypeParser<Elf64Addr> {
 #[repr(u32)]
 pub enum ShFlags {
     Write = 0x01,
+}
+
+pub struct ShFlagsParser<E>
+where
+    E: DataEncoding,
+{
+    endianness: std::marker::PhantomData<E>,
+}
+
+impl<E> ShFlagsParser<E>
+where
+    E: DataEncoding,
+{
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<E> Default for ShFlagsParser<E>
+where
+    E: DataEncoding,
+{
+    fn default() -> Self {
+        Self {
+            endianness: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'a, E> parcel::Parser<'a, &'a [u8], ShFlags> for ShFlagsParser<E>
+where
+    EiData: From<E>,
+    E: DataEncoding + Default + 'static,
+{
+    fn parse(&self, input: &'a [u8]) -> parcel::ParseResult<'a, &'a [u8], ShFlags> {
+        let encoding = EiData::from(E::default());
+
+        parcel::one_of(vec![
+            expect_u32(encoding, ShFlags::Write as u32).map(|_| ShFlags::Write)
+        ])
+        .parse(input)
+    }
 }
 
 /// Section header represents a Elf Program header.


### PR DESCRIPTION
# Introduction
This is a first pass at implementing section header parsers for both 32 and 64bit on each endianness.

# Linked Issues
#7 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
